### PR TITLE
json value iterators changed to const_interator

### DIFF
--- a/Razberry.cpp
+++ b/Razberry.cpp
@@ -350,7 +350,7 @@ void CRazberry::InsertControl(_tZWaveDevice device, const string& ctrl_id)
 
 void CRazberry::parseDevices(const Json::Value& devroot)
 {
-    for (Json::Value::iterator itt = devroot.begin(); itt != devroot.end(); ++itt) {
+    for (Json::Value::const_iterator itt = devroot.begin(); itt != devroot.end(); ++itt) {
         const std::string devID = itt.key().asString();
 
         unsigned long nodeID = atol(devID.c_str());
@@ -379,7 +379,7 @@ void CRazberry::parseDevices(const Json::Value& devroot)
         const Json::Value nodeInstances = node["instances"];
         // For all instances
         bool haveMultipleInstance = (nodeInstances.size() > 1);
-        for (Json::Value::iterator ittInstance = nodeInstances.begin();
+        for (Json::Value::const_iterator ittInstance = nodeInstances.begin();
              ittInstance != nodeInstances.end(); ++ittInstance) {
             _device.commandClassID = 0;
             _device.scaleID = -1;
@@ -436,7 +436,7 @@ void CRazberry::parseDevices(const Json::Value& devroot)
                     InsertControl(_device, control_id);
                 } else {
                     const Json::Value inVal = instance["commandClasses"]["48"]["data"];
-                    for (Json::Value::iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
+                    for (Json::Value::const_iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
                         const std::string sKey = itt2.key().asString();
                         int sensorID;
                         try {
@@ -469,7 +469,7 @@ void CRazberry::parseDevices(const Json::Value& devroot)
                 _device.commandClassID = 49;
                 _device.scaleMultiply = 1;
                 const Json::Value inVal = instance["commandClasses"]["49"]["data"];
-                for (Json::Value::iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
+                for (Json::Value::const_iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
                     const std::string sKey = itt2.key().asString();
                     try {
                         _device.scaleID = std::stoi(sKey);
@@ -508,7 +508,7 @@ void CRazberry::parseDevices(const Json::Value& devroot)
             if (instance["commandClasses"]["50"].empty() == false) {
                 // COMMAND_CLASS_METER
                 const Json::Value inVal = instance["commandClasses"]["50"]["data"];
-                for (Json::Value::iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
+                for (Json::Value::const_iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
                     try {
                         _device.scaleID = std::stoi(itt2.key().asString());
                     } catch (...) {
@@ -551,7 +551,7 @@ void CRazberry::parseDevices(const Json::Value& devroot)
             if (instance["commandClasses"]["50"].empty() == false) {
                 // COMMAND_CLASS_METER
                 const Json::Value inVal = instance["commandClasses"]["50"]["data"];
-                for (Json::Value::iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
+                for (Json::Value::const_iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
                     try {
                         _device.scaleID = std::stoi(itt2.key().asString());
                     } catch (...) {
@@ -602,7 +602,7 @@ void CRazberry::parseDevices(const Json::Value& devroot)
             if (instance["commandClasses"]["67"].empty() == false) {
                 // COMMAND_CLASS_THERMOSTAT_SETPOINT
                 const Json::Value inVal = instance["commandClasses"]["67"]["data"];
-                for (Json::Value::iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
+                for (Json::Value::const_iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
                     const std::string sKey = itt2.key().asString();
                     try {
                         _device.sensorID = std::stoi(sKey);
@@ -620,7 +620,7 @@ void CRazberry::parseDevices(const Json::Value& devroot)
             } else if (instance["commandClasses"]["156"].empty() == false) {
                 // COMMAND_CLASS_SENSOR_ALARM
                 const Json::Value inVal = instance["commandClasses"]["156"]["data"];
-                for (Json::Value::iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
+                for (Json::Value::const_iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
                     const std::string sKey = itt2.key().asString();
                     try {
                         _device.sensorID = std::stoi(sKey);


### PR DESCRIPTION
I got such errors at building package on debian stretch: 
```
Razberry.cpp:439:66: error: conversion from ‘Json::Value::const_iterator {aka Json::ValueConstIterator}’ to non-scalar type ‘Json::Value::iterator {aka Json::ValueIterator}’ requested
                     for (Json::Value::iterator itt2 = inVal.begin(); itt2 != inVal.end(); ++itt2) {
```
There was a conversation error, maybe it didn't cause error before. I built package on debian wheezy too and package was built successfuly. 


